### PR TITLE
solr service fix, when sudo is used to run init

### DIFF
--- a/src/Command/Initialize.php
+++ b/src/Command/Initialize.php
@@ -105,6 +105,7 @@ class Initialize extends Command
             ],
             0755
         );
+        $fs->chmod("{$provisioningFolder}/dev/solr", 0777);
 
         // PHP.ini ADAPTATION
         $phpINIPath = "{$provisioningFolder}/dev/engine/php.ini";


### PR DESCRIPTION
(cherry picked from commit a4083048d0112e8525908b23a910b7763619a5fa)

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | conversation on slack -->

There will be permissions issue without this fix, when init is done using sudo
