### PR TITLE
[WIP] Platformsh integration

### DIFF
--- a/box.json
+++ b/box.json
@@ -11,11 +11,13 @@
     "directories": [
         "src",
         "config",
-        "payload"
+        "payload",
+        "payload/platformsh/.platform"
     ],
     "files": [
         "LICENSE",
-        "payload/dev/solr/.gitignore"
+        "payload/dev/solr/.gitignore",
+        "payload/platformsh/.platform.app.yml"
     ],
     "finder": [
         {

--- a/box.json
+++ b/box.json
@@ -17,7 +17,7 @@
     "files": [
         "LICENSE",
         "payload/dev/solr/.gitignore",
-        "payload/platformsh/.platform.app.yml"
+        "payload/platformsh/.platform.app.yaml"
     ],
     "finder": [
         {

--- a/config/commands.yml
+++ b/config/commands.yml
@@ -15,8 +15,8 @@ services:
             - { name: ezlaunchpad.command }
 
     # Docker Actions
-    ez.launchpad.initialize:
-        class: eZ\Launchpad\Command\Initialize
+    ez.launchpad.docker.initialize:
+        class: eZ\Launchpad\Command\Docker\Initialize
         arguments:
             - "@ezlaunchpad_project.information.dumper"
         calls:
@@ -24,8 +24,8 @@ services:
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.create:
-        class: eZ\Launchpad\Command\Create
+    ez.launchpad.docker.create:
+        class: eZ\Launchpad\Command\Docker\Create
         arguments:
             - "@ezlaunchpad_project.information.dumper"
         calls:
@@ -33,68 +33,81 @@ services:
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.start:
-        class: eZ\Launchpad\Command\Start
+    ez.launchpad.docker.start:
+        class: eZ\Launchpad\Command\Docker\Start
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.build:
-        class: eZ\Launchpad\Command\Build
+    ez.launchpad.docker.build:
+        class: eZ\Launchpad\Command\Docker\Build
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.up:
-        class: eZ\Launchpad\Command\Up
+    ez.launchpad.docker.up:
+        class: eZ\Launchpad\Command\Docker\Up
         tags:
             - { name: ezlaunchpad.command }
 
     ez.launchpad.stop:
-        class: eZ\Launchpad\Command\Stop
+        class: eZ\Launchpad\Command\Docker\Stop
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.clean:
-        class: eZ\Launchpad\Command\Clean
+    ez.launchpad.docker.clean:
+        class: eZ\Launchpad\Command\Docker\Clean
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.status:
-        class: eZ\Launchpad\Command\Status
+    ez.launchpad.docker.status:
+        class: eZ\Launchpad\Command\Docker\Status
         arguments:
             - "@ezlaunchpad_project.information.dumper"
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.enter:
-        class: eZ\Launchpad\Command\Enter
+    ez.launchpad.docker.enter:
+        class: eZ\Launchpad\Command\Docker\Enter
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.logs:
-        class: eZ\Launchpad\Command\Logs
+    ez.launchpad.docker.logs:
+        class: eZ\Launchpad\Command\Docker\Logs
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.dumpdata:
-        class: eZ\Launchpad\Command\DumpData
+    ez.launchpad.docker.dumpdata:
+        class: eZ\Launchpad\Command\Docker\DumpData
         calls:
             - [setRequiredRecipes, [ [ 'create_dump' ] ] ]
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.importdata:
-        class: eZ\Launchpad\Command\ImportData
+    ez.launchpad.docker.importdata:
+        class: eZ\Launchpad\Command\Docker\ImportData
         calls:
             - [setRequiredRecipes, [ [ 'import_dump' ] ] ]
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.sfrun:
-        class: eZ\Launchpad\Command\SymfonyRun
+    ez.launchpad.docker.sfrun:
+        class: eZ\Launchpad\Command\Docker\SymfonyRun
         tags:
             - { name: ezlaunchpad.command }
 
-    ez.launchpad.comprun:
-        class: eZ\Launchpad\Command\ComposerRun
+    ez.launchpad.docker.comprun:
+        class: eZ\Launchpad\Command\Docker\ComposerRun
+        tags:
+            - { name: ezlaunchpad.command }
+
+    # Docker Actions
+    ez.launchpad.platformsh.setup:
+        class: eZ\Launchpad\Command\Platformsh\Setup
+        calls:
+            - [setRequiredRecipes, [ [ 'create_dump' ] ] ]
+        tags:
+            - { name: ezlaunchpad.command }
+
+    ez.launchpad.platformsh.deploy:
+        class: eZ\Launchpad\Command\Platformsh\Deploy
         tags:
             - { name: ezlaunchpad.command }

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,12 +61,13 @@
             <ul class="nav navbar-nav">
                 <li><a href="#installation">Installation</a></li>
                 <li><a href="#usage">Usage</a></li>
-                <li><a href="#stack">Stack</a></li>
                 <li><a href="#commands">Commands</a></li>
+                <li><a href="#deploy">Deployment</a></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">More
                         <span class="caret"></span></a>
                     <ul class="dropdown-menu ezlp-submenu">
+                        <li><a href="#stack">Stack</a></li>
                         <li><a href="#d4m">Mac OS X optimizations with D4M</a></li>
                         <li><a href="#home">Global configurations</a></li>
                     </ul>
@@ -116,10 +117,10 @@
     <div>
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#installioncurl" aria-controls="home" role="tab" data-toggle="tab">curl</a>
+                <a href="#installioncurl" aria-controls="installioncurl" role="tab" data-toggle="tab">curl</a>
             </li>
             <li role="presentation">
-                <a href="#installionwget" aria-controls="profile" role="tab" data-toggle="tab">wget</a>
+                <a href="#installionwget" aria-controls="installionwget" role="tab" data-toggle="tab">wget</a>
             </li>
         </ul>
         <div class="tab-content">
@@ -158,10 +159,10 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#initstack" aria-controls="home" role="tab" data-toggle="tab">Start from scratch</a>
+                <a href="#initstack" aria-controls="initstack" role="tab" data-toggle="tab">Start from scratch</a>
             </li>
             <li role="presentation">
-                <a href="#createstack" aria-controls="profile" role="tab" data-toggle="tab">Boostrap an existing project</a>
+                <a href="#createstack" aria-controls="createstack" role="tab" data-toggle="tab">Boostrap an existing project</a>
             </li>
         </ul>
 
@@ -263,6 +264,61 @@
         </div>
     </div>
 
+    <h2 id="deploy"><i class="fa fa-th-list" aria-hidden="true"></i> Deployment</h2>
+    <div>
+        <p>eZ Launchpad can help you to deploy as well. Even if it is optional and you can deploy the way you want we wanted to provide simplifications.
+</p>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">Platform.sh</a>
+            </li>
+            <li role="presentation">
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS<small>(@todo)</small></a>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="deploy-psh">
+                <h3>Setup</h3>
+                <p><a href="https://platform.sh/product">Platform.sh</a> is a PaaS (<strong>P</strong>latform <strong>a</strong>s <strong>a</strong> <strong>S</strong>ervice)<br /> With Platform.sh there is no real deployment process to run manually. Platform.sh will just create and synchronize environments based on your git repository!
+</p>
+                <p>eZ Launchpad provides you a way to set up your eZ Project to be Platform.sh ready.
+</p>
+
+                    <div class="highlight">
+        <button class="to-clipboard">
+            <i class="fa fa-clipboard" aria-hidden="true"></i> Copy
+        </button>
+        <pre>$ <code>~/ez platformsh:setup</code></pre>
+    </div>
+
+                <p>This command will create and generate files required by Platform.sh. Because eZ Launchpad knows your project and the services you need it will adapt the Plaftorm.sh configuration files to it.
+</p>
+                <p>Here is the list of files that are going to be created.</p>
+                <div class="highlight">
+                    <pre><code>.platform/services.yaml
+.platform/routes.yaml
+.platform.app.yaml
+ezplatform/app/config/env/platformsh.php</code></pre>
+                </div>
+                <p>Because you will need to initialize the database and the storage on Platform.sh (the first time), eZ Launchpad will also create a dump.</p>
+
+                <h3>Deploy</h3>
+                <p>As mentioned there is not real "deployment" process, this command will just display some documentation.
+</p>
+                    <div class="highlight">
+        <button class="to-clipboard">
+            <i class="fa fa-clipboard" aria-hidden="true"></i> Copy
+        </button>
+        <pre>$ <code>~/ez platformsh:deploy</code></pre>
+    </div>
+
+            </div>
+            <div role="tabpanel" class="tab-pane" id="deploy-aws">
+                <p>Coming soon...</p>
+            </div>
+        </div>
+    </div>
+
     <h2 id="stack"><i class="fa fa-th-list" aria-hidden="true"></i> Stack</h2>
     <div>
         <p>At anytime you can get information on your stack by running</p>
@@ -277,9 +333,11 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#lempstack" aria-controls="home" role="tab" data-toggle="tab">LEMP</a></li>
+                <a href="#lempstack" aria-controls="lempstack" role="tab" data-toggle="tab">LEMP</a></li>
             <li role="presentation">
-                <a href="#lampstack" aria-controls="profile" role="tab" data-toggle="tab">LAMP</a></li>
+                <a href="#lampstack" aria-controls="lampstack" role="tab" data-toggle="tab">LAMP
+                    <small>(@todo?)</small>
+                </a></li>
         </ul>
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="lempstack">
@@ -323,7 +381,10 @@ Available commands:
   docker:start       [start] Start all the services (or just one).
   docker:status      [docker:ps|docker:info|ps|info] Obtaining the project information.
   docker:stop        [stop] Stop all the services (or just one).
-  docker:up          [up] Up all the services (or just one).</code></pre>
+  docker:up          [up] Up all the services (or just one).
+ platformsh
+  platformsh:deploy  [psh:deploy] Deploy with Platformsh integration.
+  platformsh:setup   [psh:setup] Set up the Platformsh integration.</code></pre>
         </div>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -105,14 +105,33 @@
 
     <h2 id="screencast"><i class="fa fa-play" aria-hidden="true"></i> Demo</h2>
     <div>
-        <p>This is a demo of an <a href="#initstack">initialization</a>, starting from scratch, you will get everything ready to code, commit and push!
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#screeninit" aria-controls="screeninit" role="tab" data-toggle="tab">Init<small>ialization</small></a>
+            </li>
+            <li role="presentation">
+                <a href="#screencreate" aria-controls="screencreate" role="tab" data-toggle="tab">Create</a>
+            </li>
+        </ul>
+
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="screeninit">
+                <p>This is a demo of an <a href="#initstack">initialization</a>. Starting from scratch you will get everything ready to code, commit and push!
 </p>
-        <center>
-            <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
-        </center>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="screencreate">
+                <p>This is a demo of a <a href="#createstack">creation</a>. Starting from a git repository you will get everything ready to code, commit and push!
+</p>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/ap4tdnGApWI" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+        </div>
+
     </div>
-
-
     <h2 id="installation"><i class="fa fa-magic" aria-hidden="true"></i> Installation</h2>
     <div>
         <ul class="nav nav-tabs" role="tablist">
@@ -273,7 +292,9 @@
                 <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">Platform.sh</a>
             </li>
             <li role="presentation">
-                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS<small>(@todo)</small></a>
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS
+                    <small>(@todo)</small>
+                </a>
             </li>
         </ul>
         <div class="tab-content">

--- a/docs/index_fr_FR.html
+++ b/docs/index_fr_FR.html
@@ -61,12 +61,13 @@
             <ul class="nav navbar-nav">
                 <li><a href="#installation">Installation</a></li>
                 <li><a href="#usage">Usage</a></li>
-                <li><a href="#stack">Stack</a></li>
                 <li><a href="#commands">Commandes</a></li>
+                <li><a href="#deploy">Déploiement</a></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Plus
                         <span class="caret"></span></a>
                     <ul class="dropdown-menu ezlp-submenu">
+                        <li><a href="#stack">Stack</a></li>
                         <li><a href="#d4m">Mac OS X optimisations avec D4M</a></li>
                         <li><a href="#home">Configurations globales</a></li>
                     </ul>
@@ -116,10 +117,10 @@
     <div>
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#installioncurl" aria-controls="home" role="tab" data-toggle="tab">curl</a>
+                <a href="#installioncurl" aria-controls="installioncurl" role="tab" data-toggle="tab">curl</a>
             </li>
             <li role="presentation">
-                <a href="#installionwget" aria-controls="profile" role="tab" data-toggle="tab">wget</a>
+                <a href="#installionwget" aria-controls="installionwget" role="tab" data-toggle="tab">wget</a>
             </li>
         </ul>
         <div class="tab-content">
@@ -158,10 +159,10 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#initstack" aria-controls="home" role="tab" data-toggle="tab">Démarrer de rien</a>
+                <a href="#initstack" aria-controls="initstack" role="tab" data-toggle="tab">Démarrer de rien</a>
             </li>
             <li role="presentation">
-                <a href="#createstack" aria-controls="profile" role="tab" data-toggle="tab">Démarrer d'un projet existant</a>
+                <a href="#createstack" aria-controls="createstack" role="tab" data-toggle="tab">Démarrer d'un projet existant</a>
             </li>
         </ul>
 
@@ -263,6 +264,61 @@
         </div>
     </div>
 
+    <h2 id="deploy"><i class="fa fa-th-list" aria-hidden="true"></i> Déploiement</h2>
+    <div>
+        <p>eZ Launchpad peut également vous aider à deployer. Même si c'est optionnel et que vous pouvez déployer comme bon vous semble, nous voulions vous simplifier la tâche.
+</p>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">Platform.sh</a>
+            </li>
+            <li role="presentation">
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS<small>(@todo)</small></a>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="deploy-psh">
+                <h3>Configuration</h3>
+                <p><a href="https://platform.sh/product">Platform.sh</a> est une PaaS (<strong>P</strong>latform <strong>a</strong>s <strong>a</strong> <strong>S</strong>ervice)<br /> Avec Platform.sh il n'y a pas vraiment de processus de déploiement manuel. Platform.sh va simplement créer et synchroniser les environments selon le repository git!
+</p>
+                <p>eZ Launchpad va vous permettre de configurer le projet pour fonctionner avec Platform.sh.
+</p>
+
+                    <div class="highlight">
+        <button class="to-clipboard">
+            <i class="fa fa-clipboard" aria-hidden="true"></i> Copier
+        </button>
+        <pre>$ <code>~/ez platformsh:setup</code></pre>
+    </div>
+
+                <p>Cette commande va créer et générer les fichiers requis par Platform.sh. Comme eZ Launchpad connait votre projet et vos services il va adapter les fichiers de configuration Platform.sh
+</p>
+                <p>Voici la liste des fichier qui vont être créés.</p>
+                <div class="highlight">
+                    <pre><code>.platform/services.yaml
+.platform/routes.yaml
+.platform.app.yaml
+ezplatform/app/config/env/platformsh.php</code></pre>
+                </div>
+                <p>Vous aurez besoin d'initialiser la base de données et le storage sur Platform.sh (la première fois), eZ Launchpad va donc aussi créer un dump.</p>
+
+                <h3>Deploiement</h3>
+                <p>Comment déjà mentionné, il n'y a pas vraiment de processus de déploiement, cette command va juste afficher de la documentation.
+</p>
+                    <div class="highlight">
+        <button class="to-clipboard">
+            <i class="fa fa-clipboard" aria-hidden="true"></i> Copier
+        </button>
+        <pre>$ <code>~/ez platformsh:deploy</code></pre>
+    </div>
+
+            </div>
+            <div role="tabpanel" class="tab-pane" id="deploy-aws">
+                <p>Bientôt disponible...</p>
+            </div>
+        </div>
+    </div>
+
     <h2 id="stack"><i class="fa fa-th-list" aria-hidden="true"></i> Stack</h2>
     <div>
         <p>N'importe quand vous pouvez avoir de l'information sur votre stack</p>
@@ -277,9 +333,11 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#lempstack" aria-controls="home" role="tab" data-toggle="tab">LEMP</a></li>
+                <a href="#lempstack" aria-controls="lempstack" role="tab" data-toggle="tab">LEMP</a></li>
             <li role="presentation">
-                <a href="#lampstack" aria-controls="profile" role="tab" data-toggle="tab">LAMP</a></li>
+                <a href="#lampstack" aria-controls="lampstack" role="tab" data-toggle="tab">LAMP
+                    <small>(@todo?)</small>
+                </a></li>
         </ul>
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="lempstack">
@@ -323,7 +381,10 @@ Available commands:
   docker:start       [start] Start all the services (or just one).
   docker:status      [docker:ps|docker:info|ps|info] Obtaining the project information.
   docker:stop        [stop] Stop all the services (or just one).
-  docker:up          [up] Up all the services (or just one).</code></pre>
+  docker:up          [up] Up all the services (or just one).
+ platformsh
+  platformsh:deploy  [psh:deploy] Deploy with Platformsh integration.
+  platformsh:setup   [psh:setup] Set up the Platformsh integration.</code></pre>
         </div>
 
 

--- a/docs/index_fr_FR.html
+++ b/docs/index_fr_FR.html
@@ -105,14 +105,33 @@
 
     <h2 id="screencast"><i class="fa fa-play" aria-hidden="true"></i> Demonstration</h2>
     <div>
-        <p>Voici une démonstration de l'utilisation de l'<a href="#initstack">initialization</a> d'un projet en ne partant de rien. Cela va installer tout la stack pour vous, et vous permettre de code, commit et pusher!
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#screeninit" aria-controls="screeninit" role="tab" data-toggle="tab">Init<small>ialisation</small></a>
+            </li>
+            <li role="presentation">
+                <a href="#screencreate" aria-controls="screencreate" role="tab" data-toggle="tab">Creation</a>
+            </li>
+        </ul>
+
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="screeninit">
+                <p>Voici une démonstration de l'utilisation de l'<a href="#initstack">initialization</a> d'un projet en ne partant de rien. Cela va installer tout la stack pour vous, et vous permettre de code, commit et pusher!
 </p>
-        <center>
-            <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
-        </center>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="screencreate">
+                <p>Voici une démonstration de l'utilisation de la<a href="#createstack">creation</a> d'un projet en partant d'un dépot git. Cela va installer tout la stack pour vous, et vous permettre de code, commit et pusher!
+</p>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/ap4tdnGApWI" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+        </div>
+
     </div>
-
-
     <h2 id="installation"><i class="fa fa-magic" aria-hidden="true"></i> Installation</h2>
     <div>
         <ul class="nav nav-tabs" role="tablist">
@@ -273,7 +292,9 @@
                 <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">Platform.sh</a>
             </li>
             <li role="presentation">
-                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS<small>(@todo)</small></a>
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS
+                    <small>(@todo)</small>
+                </a>
             </li>
         </ul>
         <div class="tab-content">

--- a/docs/index_no_NO.html
+++ b/docs/index_no_NO.html
@@ -61,12 +61,13 @@
             <ul class="nav navbar-nav">
                 <li><a href="#installation">Installasjon</a></li>
                 <li><a href="#usage">Bruk</a></li>
-                <li><a href="#stack">Stack</a></li>
                 <li><a href="#commands">Kommandoer</a></li>
+                <li><a href="#deploy">Deployment</a></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Mer
                         <span class="caret"></span></a>
                     <ul class="dropdown-menu ezlp-submenu">
+                        <li><a href="#stack">Stack</a></li>
                         <li><a href="#d4m">Mac OS X optimalisering med D4M</a></li>
                         <li><a href="#home">Global konfigurasjon</a></li>
                     </ul>
@@ -116,10 +117,10 @@
     <div>
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#installioncurl" aria-controls="home" role="tab" data-toggle="tab">curl</a>
+                <a href="#installioncurl" aria-controls="installioncurl" role="tab" data-toggle="tab">curl</a>
             </li>
             <li role="presentation">
-                <a href="#installionwget" aria-controls="profile" role="tab" data-toggle="tab">wget</a>
+                <a href="#installionwget" aria-controls="installionwget" role="tab" data-toggle="tab">wget</a>
             </li>
         </ul>
         <div class="tab-content">
@@ -158,10 +159,10 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#initstack" aria-controls="home" role="tab" data-toggle="tab">Start fra bunn</a>
+                <a href="#initstack" aria-controls="initstack" role="tab" data-toggle="tab">Start fra bunn</a>
             </li>
             <li role="presentation">
-                <a href="#createstack" aria-controls="profile" role="tab" data-toggle="tab">Boostrap et eksisterende prosjekt</a>
+                <a href="#createstack" aria-controls="createstack" role="tab" data-toggle="tab">Boostrap et eksisterende prosjekt</a>
             </li>
         </ul>
 
@@ -263,6 +264,61 @@
         </div>
     </div>
 
+    <h2 id="deploy"><i class="fa fa-th-list" aria-hidden="true"></i> Deployment</h2>
+    <div>
+        <p>eZ Launchpad can help you to deploy as well. Even if it is optional and you can deploy the way you want we wanted to provide simplifications.
+</p>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">Platform.sh</a>
+            </li>
+            <li role="presentation">
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS<small>(@todo)</small></a>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="deploy-psh">
+                <h3>Setup</h3>
+                <p><a href="https://platform.sh/product">Platform.sh</a> is a PaaS (<strong>P</strong>latform <strong>a</strong>s <strong>a</strong> <strong>S</strong>ervice)<br /> With Platform.sh there is no real deployment process to run manually. Platform.sh will just create and synchronize environments based on your git repository!
+</p>
+                <p>eZ Launchpad provides you a way to set up your eZ Project to be Platform.sh ready.
+</p>
+
+                    <div class="highlight">
+        <button class="to-clipboard">
+            <i class="fa fa-clipboard" aria-hidden="true"></i> Kopier
+        </button>
+        <pre>$ <code>~/ez platformsh:setup</code></pre>
+    </div>
+
+                <p>This command will create and generate files required by Platform.sh. Because eZ Launchpad knows your project and the services you need it will adapt the Plaftorm.sh configuration files to it.
+</p>
+                <p>Here is the list of files that are going to be created.</p>
+                <div class="highlight">
+                    <pre><code>.platform/services.yaml
+.platform/routes.yaml
+.platform.app.yaml
+ezplatform/app/config/env/platformsh.php</code></pre>
+                </div>
+                <p>Because you will need to initialize the database and the storage on Platform.sh (the first time), eZ Launchpad will also create a dump.</p>
+
+                <h3>Deploy</h3>
+                <p>As mentioned there is not real "deployment" process, this command will just display some documentation.
+</p>
+                    <div class="highlight">
+        <button class="to-clipboard">
+            <i class="fa fa-clipboard" aria-hidden="true"></i> Kopier
+        </button>
+        <pre>$ <code>~/ez platformsh:deploy</code></pre>
+    </div>
+
+            </div>
+            <div role="tabpanel" class="tab-pane" id="deploy-aws">
+                <p>Coming soon...</p>
+            </div>
+        </div>
+    </div>
+
     <h2 id="stack"><i class="fa fa-th-list" aria-hidden="true"></i> Stack</h2>
     <div>
         <p>Du kan når som helst få informasjon om din stack ved å kjøre</p>
@@ -277,9 +333,11 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#lempstack" aria-controls="home" role="tab" data-toggle="tab">LEMP</a></li>
+                <a href="#lempstack" aria-controls="lempstack" role="tab" data-toggle="tab">LEMP</a></li>
             <li role="presentation">
-                <a href="#lampstack" aria-controls="profile" role="tab" data-toggle="tab">LAMP</a></li>
+                <a href="#lampstack" aria-controls="lampstack" role="tab" data-toggle="tab">LAMP
+                    <small>(@todo?)</small>
+                </a></li>
         </ul>
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="lempstack">
@@ -323,7 +381,10 @@ Available commands:
   docker:start       [start] Start all the services (or just one).
   docker:status      [docker:ps|docker:info|ps|info] Obtaining the project information.
   docker:stop        [stop] Stop all the services (or just one).
-  docker:up          [up] Up all the services (or just one).</code></pre>
+  docker:up          [up] Up all the services (or just one).
+ platformsh
+  platformsh:deploy  [psh:deploy] Deploy with Platformsh integration.
+  platformsh:setup   [psh:setup] Set up the Platformsh integration.</code></pre>
         </div>
 
 

--- a/docs/index_no_NO.html
+++ b/docs/index_no_NO.html
@@ -105,14 +105,33 @@
 
     <h2 id="screencast"><i class="fa fa-play" aria-hidden="true"></i> Demo</h2>
     <div>
-        <p>Dette er en demo av <a href="#initstack">initialisering</a> hvor du får alt du trenger for å kode, committe og pushe!
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#screeninit" aria-controls="screeninit" role="tab" data-toggle="tab">Init<small>ialisering</small></a>
+            </li>
+            <li role="presentation">
+                <a href="#screencreate" aria-controls="screencreate" role="tab" data-toggle="tab">Opprett</a>
+            </li>
+        </ul>
+
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="screeninit">
+                <p>Dette er en demo av <a href="#initstack">initialisering</a> hvor du får alt du trenger for å kode, committe og pushe!
 </p>
-        <center>
-            <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
-        </center>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="screencreate">
+                <p>This is a demo of a <a href="#createstack">creation</a>. Starting from a git repository you will get everything ready to code, commit and push!
+</p>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/ap4tdnGApWI" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+        </div>
+
     </div>
-
-
     <h2 id="installation"><i class="fa fa-magic" aria-hidden="true"></i> Installasjon</h2>
     <div>
         <ul class="nav nav-tabs" role="tablist">
@@ -273,7 +292,9 @@
                 <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">Platform.sh</a>
             </li>
             <li role="presentation">
-                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS<small>(@todo)</small></a>
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">AWS
+                    <small>(@todo)</small>
+                </a>
             </li>
         </ul>
         <div class="tab-content">

--- a/docs/templates/header.html.twig
+++ b/docs/templates/header.html.twig
@@ -17,12 +17,13 @@
             <ul class="nav navbar-nav">
                 <li><a href="#installation">{{ "header.menu.installation"|trans }}</a></li>
                 <li><a href="#usage">{{ "header.menu.usage"|trans }}</a></li>
-                <li><a href="#stack">{{ "header.menu.stack"|trans }}</a></li>
                 <li><a href="#commands">{{ "header.menu.commands"|trans }}</a></li>
+                <li><a href="#deploy">{{ "header.menu.deploy"|trans }}</a></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ "header.menu.more"|trans }}
                         <span class="caret"></span></a>
                     <ul class="dropdown-menu ezlp-submenu">
+                        <li><a href="#stack">{{ "header.menu.stack"|trans }}</a></li>
                         <li><a href="#d4m">{{ "header.menu.d4m"|trans }}</a></li>
                         <li><a href="#home">{{ "header.menu.global.configuration"|trans }}</a></li>
                     </ul>

--- a/docs/templates/index.html.twig
+++ b/docs/templates/index.html.twig
@@ -34,10 +34,10 @@
     <div>
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#installioncurl" aria-controls="home" role="tab" data-toggle="tab">curl</a>
+                <a href="#installioncurl" aria-controls="installioncurl" role="tab" data-toggle="tab">curl</a>
             </li>
             <li role="presentation">
-                <a href="#installionwget" aria-controls="profile" role="tab" data-toggle="tab">wget</a>
+                <a href="#installionwget" aria-controls="installionwget" role="tab" data-toggle="tab">wget</a>
             </li>
         </ul>
         <div class="tab-content">
@@ -64,10 +64,10 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#initstack" aria-controls="home" role="tab" data-toggle="tab">{{ "content.usage.fromscratch"|trans|raw }}</a>
+                <a href="#initstack" aria-controls="initstack" role="tab" data-toggle="tab">{{ "content.usage.fromscratch"|trans|raw }}</a>
             </li>
             <li role="presentation">
-                <a href="#createstack" aria-controls="profile" role="tab" data-toggle="tab">{{ "content.usage.bootstrap"|trans|raw }}</a>
+                <a href="#createstack" aria-controls="createstack" role="tab" data-toggle="tab">{{ "content.usage.bootstrap"|trans|raw }}</a>
             </li>
         </ul>
 
@@ -123,6 +123,44 @@
         </div>
     </div>
 
+    <h2 id="deploy"><i class="fa fa-th-list" aria-hidden="true"></i> {{ "content.deploy.title"|trans|raw }}</h2>
+    <div>
+        <p>{{ "content.deploy.blurb"|trans|raw }}</p>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">{{ "content.deploy.platformsh"|trans|raw }}</a>
+            </li>
+            <li role="presentation">
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">{{ "content.deploy.aws"|trans|raw }}<small>(@todo)</small></a>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="deploy-psh">
+                <h3>{{ "content.deploy.platformsh.setup.subtitle"|trans|raw }}</h3>
+                <p>{{ "content.deploy.platformsh.blurb"|trans|raw }}</p>
+                <p>{{ "content.deploy.platformsh.blurb2"|trans|raw }}</p>
+
+                {{ CodeHelper.show("~/ez platformsh:setup") }}
+                <p>{{ "content.deploy.platformsh.setup.blurb"|trans|raw }}</p>
+                <p>{{ "content.deploy.platformsh.setup.listfile"|trans|raw }}</p>
+                <div class="highlight">
+                    <pre><code>.platform/services.yaml
+.platform/routes.yaml
+.platform.app.yaml
+ezplatform/app/config/env/platformsh.php</code></pre>
+                </div>
+                <p>{{ "content.deploy.platformsh.setup.dump"|trans|raw }}</p>
+
+                <h3>{{ "content.deploy.platformsh.deploy.subtitle"|trans|raw }}</h3>
+                <p>{{ "content.deploy.platformsh.deploy.blurb"|trans|raw }}</p>
+                {{ CodeHelper.show("~/ez platformsh:deploy") }}
+            </div>
+            <div role="tabpanel" class="tab-pane" id="deploy-aws">
+                <p>{{ "other.soon"|trans|raw }}</p>
+            </div>
+        </div>
+    </div>
+
     <h2 id="stack"><i class="fa fa-th-list" aria-hidden="true"></i> {{ "content.stack.title"|trans|raw }}</h2>
     <div>
         <p>{{ "content.stack.blurb"|trans|raw }}</p>
@@ -131,9 +169,11 @@
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a href="#lempstack" aria-controls="home" role="tab" data-toggle="tab">LEMP</a></li>
+                <a href="#lempstack" aria-controls="lempstack" role="tab" data-toggle="tab">LEMP</a></li>
             <li role="presentation">
-                <a href="#lampstack" aria-controls="profile" role="tab" data-toggle="tab">LAMP</a></li>
+                <a href="#lampstack" aria-controls="lampstack" role="tab" data-toggle="tab">LAMP
+                    <small>(@todo?)</small>
+                </a></li>
         </ul>
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="lempstack">
@@ -177,7 +217,10 @@ Available commands:
   docker:start       [start] Start all the services (or just one).
   docker:status      [docker:ps|docker:info|ps|info] Obtaining the project information.
   docker:stop        [stop] Stop all the services (or just one).
-  docker:up          [up] Up all the services (or just one).</code></pre>
+  docker:up          [up] Up all the services (or just one).
+ platformsh
+  platformsh:deploy  [psh:deploy] Deploy with Platformsh integration.
+  platformsh:setup   [psh:setup] Set up the Platformsh integration.</code></pre>
         </div>
 
 

--- a/docs/templates/index.html.twig
+++ b/docs/templates/index.html.twig
@@ -23,13 +23,31 @@
 
     <h2 id="screencast"><i class="fa fa-play" aria-hidden="true"></i> {{ "content.demo.title"|trans|raw }}</h2>
     <div>
-        <p>{{ "content.demo.blurb"|trans|raw }}</p>
-        <center>
-            <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
-        </center>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active">
+                <a href="#screeninit" aria-controls="screeninit" role="tab" data-toggle="tab">{{ "content.usage.init.title"|trans|raw }}</a>
+            </li>
+            <li role="presentation">
+                <a href="#screencreate" aria-controls="screencreate" role="tab" data-toggle="tab">{{ "content.usage.create.title"|trans|raw }}</a>
+            </li>
+        </ul>
+
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="screeninit">
+                <p>{{ "content.demo.blurb"|trans|raw }}</p>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/N_wd-yAlKmA" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="screencreate">
+                <p>{{ "content.demo.create.blurb"|trans|raw }}</p>
+                <center>
+                    <iframe width="800" height="450" src="https://www.youtube.com/embed/ap4tdnGApWI" frameborder="0" allowfullscreen></iframe>
+                </center>
+            </div>
+        </div>
+
     </div>
-
-
     <h2 id="installation"><i class="fa fa-magic" aria-hidden="true"></i> {{ "content.install.title"|trans|raw }}</h2>
     <div>
         <ul class="nav nav-tabs" role="tablist">
@@ -131,7 +149,9 @@
                 <a href="#deploy-psh" aria-controls="deploy-psh" role="tab" data-toggle="tab">{{ "content.deploy.platformsh"|trans|raw }}</a>
             </li>
             <li role="presentation">
-                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">{{ "content.deploy.aws"|trans|raw }}<small>(@todo)</small></a>
+                <a href="#deploy-aws" aria-controls="deploy-aws" role="tab" data-toggle="tab">{{ "content.deploy.aws"|trans|raw }}
+                    <small>(@todo)</small>
+                </a>
             </li>
         </ul>
         <div class="tab-content">

--- a/docs/translations/messages.en_US.yml
+++ b/docs/translations/messages.en_US.yml
@@ -34,9 +34,11 @@ content:
     demo:
         title: "Demo"
         blurb: >
-            This is a demo of an <a href="#initstack">initialization</a>, starting from scratch,
+            This is a demo of an <a href="#initstack">initialization</a>. Starting from scratch
             you will get everything ready to code, commit and push!
-
+        create.blurb: >
+            This is a demo of a <a href="#createstack">creation</a>. Starting from a git repository
+            you will get everything ready to code, commit and push!
     install:
         title: "Installation"
         toolinstalled: "If you have <strong>%tool%</strong> installed:"

--- a/docs/translations/messages.en_US.yml
+++ b/docs/translations/messages.en_US.yml
@@ -9,6 +9,7 @@ header:
     menu:
         installation: "Installation"
         usage: "Usage"
+        deploy: "Deployment"
         stack: "Stack"
         commands: "Commands"
         more: "More"
@@ -80,6 +81,29 @@ content:
         create.localstack: "To create the local stack the command is then"
         create.whathasbeendone: "Here eZ Launchpad will pull the images, create the containers of your stack as well a importing the database/storage."
 
+    deploy:
+        title: "Deployment"
+        blurb: >
+            eZ Launchpad can help you to deploy as well. Even if it is optional and you can deploy the way you want
+            we wanted to provide simplifications.
+        platformsh: "Platform.sh"
+        platformsh.blurb: >
+            <a href="https://platform.sh/product">Platform.sh</a> is a PaaS (<strong>P</strong>latform <strong>a</strong>s <strong>a</strong> <strong>S</strong>ervice)<br />
+            With Platform.sh there is no real deployment process to run manually. Platform.sh will just create and synchronize environments based on your git repository!
+        platformsh.blurb2: >
+            eZ Launchpad provides you a way to set up your eZ Project to be Platform.sh ready.
+        platformsh.setup.subtitle: "Setup"
+        platformsh.setup.blurb: >
+            This command will create and generate files required by Platform.sh. Because eZ Launchpad knows your project and the services you need it will adapt the
+            Plaftorm.sh configuration files to it.
+        platformsh.setup.listfile: "Here is the list of files that are going to be created."
+        platformsh.setup.dump: "Because you will need to initialize the database and the storage on Platform.sh (the first time), eZ Launchpad will also create a dump."
+        platformsh.deploy.subtitle: "Deploy"
+        platformsh.deploy.blurb: >
+            As mentioned there is not real "deployment" process, this command will just display some documentation.
+
+        aws: "AWS"
+
     stack:
         title: "Stack"
         blurb: "At anytime you can get information on your stack by running"
@@ -125,3 +149,4 @@ content:
 
 other:
     copy: "Copy"
+    soon: "Coming soon..."

--- a/docs/translations/messages.fr_FR.yml
+++ b/docs/translations/messages.fr_FR.yml
@@ -36,7 +36,9 @@ content:
         blurb: >
             Voici une démonstration de l'utilisation de l'<a href="#initstack">initialization</a> d'un projet en
             ne partant de rien. Cela va installer tout la stack pour vous, et vous permettre de code, commit et pusher!
-
+        create.blurb: >
+            Voici une démonstration de l'utilisation de la<a href="#createstack">creation</a> d'un projet en
+            partant d'un dépot git. Cela va installer tout la stack pour vous, et vous permettre de code, commit et pusher!
     install:
         title: "Installation"
         toolinstalled: "Si vous avez <strong>%tool%</strong> d'installé:"

--- a/docs/translations/messages.fr_FR.yml
+++ b/docs/translations/messages.fr_FR.yml
@@ -9,6 +9,7 @@ header:
     menu:
         installation: "Installation"
         usage: "Usage"
+        deploy: "Déploiement"
         stack: "Stack"
         commands: "Commandes"
         more: "Plus"
@@ -80,6 +81,29 @@ content:
         create.localstack: "Pour créeer la stack locale la commande est alors"
         create.whathasbeendone: "eZ Launchpad va juste télécharger les images, créer les containers puis importer la base et le storage."
 
+    deploy:
+        title: "Déploiement"
+        blurb: >
+            eZ Launchpad peut également vous aider à deployer. Même si c'est optionnel et que vous pouvez déployer
+            comme bon vous semble, nous voulions vous simplifier la tâche.
+        platformsh: "Platform.sh"
+        platformsh.blurb: >
+            <a href="https://platform.sh/product">Platform.sh</a> est une PaaS (<strong>P</strong>latform <strong>a</strong>s <strong>a</strong> <strong>S</strong>ervice)<br />
+            Avec Platform.sh il n'y a pas vraiment de processus de déploiement manuel. Platform.sh va simplement créer et synchroniser les environments selon le repository git!
+        platformsh.blurb2: >
+            eZ Launchpad va vous permettre de configurer le projet pour fonctionner avec Platform.sh.
+        platformsh.setup.subtitle: "Configuration"
+        platformsh.setup.blurb: >
+            Cette commande va créer et générer les fichiers requis par Platform.sh. Comme eZ Launchpad connait votre projet et vos services
+            il va adapter les fichiers de configuration Platform.sh
+        platformsh.setup.listfile: "Voici la liste des fichier qui vont être créés."
+        platformsh.setup.dump: "Vous aurez besoin d'initialiser la base de données et le storage sur Platform.sh (la première fois), eZ Launchpad va donc aussi créer un dump."
+        platformsh.deploy.subtitle: "Deploiement"
+        platformsh.deploy.blurb: >
+            Comment déjà mentionné, il n'y a pas vraiment de processus de déploiement, cette command va juste afficher de la documentation.
+
+        aws: "AWS"
+
     stack:
         title: "Stack"
         blurb: "N'importe quand vous pouvez avoir de l'information sur votre stack"
@@ -125,3 +149,4 @@ content:
             <em>host_composer_cache_dir</em> permettra lui de partager le cache Composer entre vos projets.
 other:
     copy: "Copier"
+    soon: "Bientôt disponible..."

--- a/payload/platformsh/.platform.app.yaml
+++ b/payload/platformsh/.platform.app.yaml
@@ -1,0 +1,86 @@
+# eZ Launchpad - Platform.sh file boilerplate - 6/10/2017
+
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# Please see doc/platformsh/README.md and doc/platformsh/INSTALL.md
+# NB: Clustered eZ Platform setups are not tested and are likely to have issues.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The type of the application to build.
+type: php:7.1
+build:
+    # "none" means we're running composer manually, see build hook
+    flavor: "none"
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "mysqldb:mysql"
+    cache: "cache:memcache"
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            # The public directory of the app, relative to its root.
+            root: "ezplatform/web"
+            # The front-controller script to send non-static requests to.
+            passthru: "/app.php"
+            # The number of seconds whitelisted (static) content should be cache
+            expires: 600
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    "/ezplatform/app/cache": "shared:files/cache"
+    "/ezplatform/app/logs": "shared:files/logs"
+    "/ezplatform/web/var": "shared:files/files"
+
+# The hooks that will be performed when the package is deployed.
+hooks:
+    build: |
+        set -e
+        cd /app/ezplatform
+        CONSOLE="bin/console"
+        if [ -f app/console ]; then
+            CONSOLE="app/console"
+        fi
+        composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
+        rm web/app_dev.php
+        php $CONSOLE --env=prod assetic:dump
+    deploy: |
+        set -e
+        cd /app
+        if [ ! -f ezplatform/web/var/.platform.installed ]; then
+            MYSQL_OPTIONS=`php scripts/getmysqlcredentials.php`
+            zcat data/db.sql.gz | mysql $MYSQL_OPTIONS
+            touch ezplatform/web/var/.platform.installed
+        fi
+        cd /app/ezplatform
+        CONSOLE="bin/console"
+        if [ -f app/console ]; then
+            CONSOLE="app/console"
+        fi
+        php $CONSOLE --env=prod cache:clear
+
+# The configuration of scheduled execution.
+# see http://symfony.com/doc/current/components/console/introduction.html
+#crons:
+#    symfony:
+#        spec: "*/20 * * * *"
+#        cmd: "php cron.php example:test"
+
+runtime:
+    extensions:
+        - xsl
+        - imagick
+        - readline
+        - memcached
+        - msgpack

--- a/payload/platformsh/.platform.app.yaml
+++ b/payload/platformsh/.platform.app.yaml
@@ -59,8 +59,9 @@ hooks:
         set -e
         cd /app
         if [ ! -f ezplatform/web/var/.platform.installed ]; then
-            MYSQL_OPTIONS=`php scripts/getmysqlcredentials.php`
-            zcat data/db.sql.gz | mysql $MYSQL_OPTIONS
+            MYSQL_OPTIONS=`php provisioning/platformsh/getmysqlcredentials.php`
+            zcat data/ezplatform.sql.gz | mysql $MYSQL_OPTIONS
+            tar xvzf data/storage.tar.gz -C ezplatform/web/
             touch ezplatform/web/var/.platform.installed
         fi
         cd /app/ezplatform

--- a/payload/platformsh/.platform/routes.yaml
+++ b/payload/platformsh/.platform/routes.yaml
@@ -1,0 +1,11 @@
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+    cache:
+        # As this does not support Vary, and purging, we can't use this as Sf Proxy drop in.
+        # However it is possible to enable this for anonymous traffic when backend sends expiry headers.
+        enabled: false
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/payload/platformsh/.platform/services.yaml
+++ b/payload/platformsh/.platform/services.yaml
@@ -1,0 +1,2 @@
+mysqldb: { type: "mysql:10.0", disk: 2048 }
+cache: { type: "memcache:1.4" }

--- a/payload/platformsh/.platform/services.yaml
+++ b/payload/platformsh/.platform/services.yaml
@@ -1,2 +1,5 @@
-mysqldb: { type: "mysql:10.0", disk: 2048 }
-cache: { type: "memcache:1.4" }
+mysqldb:
+    type: 'mysql:10.0'
+    disk: 2048
+cache:
+    type: 'memcache:1.4'

--- a/payload/platformsh/getmysqlcredentials.php
+++ b/payload/platformsh/getmysqlcredentials.php
@@ -1,0 +1,21 @@
+<?php
+include(__DIR__."/../ezplatform/vendor/autoload.php");
+
+use Platformsh\ConfigReader\Config as PlatformshConfig;
+
+$config = new PlatformshConfig();
+if (isset($config->relationships['database'][0])) {
+    $database = $config->relationships['database'][0];
+    $string   = '';
+    if (!empty($database['username'])) {
+        $string .= " -u {$database['username']}";
+    }
+    if (!empty($database['password'])) {
+        $string .= " -p{$database['password']}";
+    }
+    if (!empty($database['host'])) {
+        $string .= " -h {$database['host']}";
+    }
+    $string .= " {$database['path']}";
+    echo $string;
+}

--- a/payload/platformsh/platformsh.php
+++ b/payload/platformsh/platformsh.php
@@ -1,0 +1,29 @@
+<?php
+include(__DIR__."/../../vendor/autoload.php");
+
+use Platformsh\ConfigReader\Config as PlatformshConfig;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader;
+
+$config = new PlatformshConfig();
+
+if (isset($config->relationships['database'][0])) {
+    $database = $config->relationships['database'][0];
+    $container->setParameter('database_driver', 'pdo_'.$database['scheme']);
+    $container->setParameter('database_host', $database['host']);
+    $container->setParameter('database_port', $database['port']);
+    $container->setParameter('database_name', $database['path']);
+    $container->setParameter('database_user', $database['username']);
+    $container->setParameter('database_password', $database['password']);
+    $container->setParameter('database_path', '');
+}
+
+if (isset($config->relationships['cache'][0])) {
+    $pool  = 'singlememcached';
+    $cache = $config->relationships['cache'][0];
+    $container->setParameter('cache_pool', $pool);
+    $container->setParameter('cache_host', $cache['host']);
+    $container->setParameter('cache_memcached_port', $cache['port']);
+    $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../cache_pool'));
+    $loader->load($pool.'.yml');
+}

--- a/payload/recipes/ez_install.bash
+++ b/payload/recipes/ez_install.bash
@@ -15,9 +15,6 @@ $COMPOSER create-project --no-interaction $REPO ezplatform $VERSION
 cp composer.phar ezplatform
 cd ezplatform
 
-# Install Tiny help for Platformsh (will be included soon in ezplatform)
-$COMPOSER require platformsh/config-reader --no-interaction
-
 # Do some cleaning
 ## Files
 rm .env .platform.app.yaml Dockerfile .travis.yml

--- a/payload/recipes/ez_install.bash
+++ b/payload/recipes/ez_install.bash
@@ -9,10 +9,20 @@ VERSION=$2
 INIT_DATA=$3
 
 echo "Installation eZ Platform ($REPO:$VERSION:$INIT_DATA) in the container"
+
 # Install
 $COMPOSER create-project --no-interaction $REPO ezplatform $VERSION
 cp composer.phar ezplatform
 cd ezplatform
+
+# Install Tiny help for Platformsh (will be included soon in ezplatform)
+$COMPOSER require platformsh/config-reader --no-interaction
+
+# Do some cleaning
+## Files
+rm .env .platform.app.yml Dockerfile .travis
+## Folder
+rm -rf .platform bin/.ci bin/.travis
 
 CONSOLE="bin/console"
 if [ -f app/console ]; then

--- a/payload/recipes/ez_install.bash
+++ b/payload/recipes/ez_install.bash
@@ -20,7 +20,7 @@ $COMPOSER require platformsh/config-reader --no-interaction
 
 # Do some cleaning
 ## Files
-rm .env .platform.app.yml Dockerfile .travis
+rm .env .platform.app.yaml Dockerfile .travis.yml
 ## Folder
 rm -rf .platform bin/.ci bin/.travis
 

--- a/src/Command/Docker/Build.php
+++ b/src/Command/Docker/Build.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -12,9 +12,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class Start.
+ * Class Build.
  */
-class Start extends DockerCommand
+class Build extends DockerCommand
 {
     /**
      * {@inheritdoc}
@@ -22,9 +22,9 @@ class Start extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:start')->setDescription('Start all the services (or just one).');
-        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to start', '');
-        $this->setAliases(['start']);
+        $this->setName('docker:build')->setDescription('Build all the services (or just one).');
+        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to build', '');
+        $this->setAliases(['build']);
     }
 
     /**
@@ -32,6 +32,6 @@ class Start extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->dockerClient->start($input->getArgument('service'));
+        $this->dockerClient->build([], $input->getArgument('service'));
     }
 }

--- a/src/Command/Docker/Clean.php
+++ b/src/Command/Docker/Clean.php
@@ -4,17 +4,16 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class Up.
+ * Class Clean.
  */
-class Up extends DockerCommand
+class Clean extends DockerCommand
 {
     /**
      * {@inheritdoc}
@@ -22,9 +21,8 @@ class Up extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:up')->setDescription('Up all the services (or just one).');
-        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to up', '');
-        $this->setAliases(['up']);
+        $this->setName('docker:clean')->setDescription('Clean all the services.');
+        $this->setAliases(['docker:down', 'clean', 'down']);
     }
 
     /**
@@ -32,6 +30,6 @@ class Up extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->dockerClient->up(['-d'], $input->getArgument('service'));
+        $this->dockerClient->down(['-v', '--remove-orphans']);
     }
 }

--- a/src/Command/Docker/ComposerRun.php
+++ b/src/Command/Docker/ComposerRun.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -12,9 +12,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class Stop.
+ * Class ComposerRun.
  */
-class Stop extends DockerCommand
+class ComposerRun extends DockerCommand
 {
     /**
      * {@inheritdoc}
@@ -22,9 +22,13 @@ class Stop extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:stop')->setDescription('Stop all the services (or just one).');
-        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to stop', '');
-        $this->setAliases(['stop']);
+        $this->setName('docker:comprun')->setDescription('Run Composer command in the engine.');
+        $this->setAliases(['comprun']);
+        $this->addArgument(
+            'compcommand',
+            InputArgument::IS_ARRAY,
+            'Composer Command to run in. Use "" to pass options.'
+        );
     }
 
     /**
@@ -32,6 +36,8 @@ class Stop extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->dockerClient->stop($input->getArgument('service'));
+        $allArguments = $input->getArgument('compcommand');
+        $options      = '';
+        $this->taskExecutor->runComposerCommand(implode(' ', $allArguments)." {$options}");
     }
 }

--- a/src/Command/Docker/DumpData.php
+++ b/src/Command/Docker/DumpData.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Command/Docker/Enter.php
+++ b/src/Command/Docker/Enter.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Command/Docker/ImportData.php
+++ b/src/Command/Docker/ImportData.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Console\Application;
 use eZ\Launchpad\Core\Client\Docker;

--- a/src/Command/Docker/Logs.php
+++ b/src/Command/Docker/Logs.php
@@ -4,16 +4,17 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class Clean.
+ * Class Logs.
  */
-class Clean extends DockerCommand
+class Logs extends DockerCommand
 {
     /**
      * {@inheritdoc}
@@ -21,8 +22,9 @@ class Clean extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:clean')->setDescription('Clean all the services.');
-        $this->setAliases(['docker:down', 'clean', 'down']);
+        $this->setName('docker:logs')->setDescription('Display the logs.');
+        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to log.', '');
+        $this->setAliases(['logs', 'log']);
     }
 
     /**
@@ -30,6 +32,6 @@ class Clean extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->dockerClient->down(['-v', '--remove-orphans']);
+        $this->dockerClient->logs(['-f', '--tail=100'], $input->getArgument('service'));
     }
 }

--- a/src/Command/Docker/Start.php
+++ b/src/Command/Docker/Start.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -12,9 +12,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class Logs.
+ * Class Start.
  */
-class Logs extends DockerCommand
+class Start extends DockerCommand
 {
     /**
      * {@inheritdoc}
@@ -22,9 +22,9 @@ class Logs extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:logs')->setDescription('Display the logs.');
-        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to log.', '');
-        $this->setAliases(['logs', 'log']);
+        $this->setName('docker:start')->setDescription('Start all the services (or just one).');
+        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to start', '');
+        $this->setAliases(['start']);
     }
 
     /**
@@ -32,6 +32,6 @@ class Logs extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->dockerClient->logs(['-f', '--tail=100'], $input->getArgument('service'));
+        $this->dockerClient->start($input->getArgument('service'));
     }
 }

--- a/src/Command/Docker/Status.php
+++ b/src/Command/Docker/Status.php
@@ -4,17 +4,18 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use eZ\Launchpad\Core\ProjectStatusDumper;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class Create.
+ * Class Status.
  */
-class Create extends DockerCommand
+class Status extends DockerCommand
 {
     /**
      * @var ProjectStatusDumper
@@ -38,8 +39,14 @@ class Create extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:create')->setDescription('Create all the services.');
-        $this->setAliases(['create']);
+        $this->setName('docker:status')->setDescription('Obtaining the project information.');
+        $this->setAliases(['docker:ps', 'docker:info', 'ps', 'info']);
+        $this->addArgument(
+            'options',
+            InputArgument::OPTIONAL,
+            'n: Docker Network, c: Docker Compose, s: Service Access',
+            'ncs'
+        );
     }
 
     /**
@@ -57,20 +64,6 @@ class Create extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->dockerClient->build(['--no-cache']);
-        $this->dockerClient->up(['-d']);
-
-        $this->taskExecutor->composerInstall();
-        $this->taskExecutor->eZCreate();
-        $this->taskExecutor->importData();
-
-        // if solr run the index
-        $compose = $this->projectConfiguration->getDockerCompose();
-        if ($compose->hasService('solr')) {
-            $this->taskExecutor->createCore();
-            $this->taskExecutor->indexSolr();
-        }
-
-        $this->projectStatusDumper->dump('ncsi');
+        $this->projectStatusDumper->dump($input->getArgument('options'));
     }
 }

--- a/src/Command/Docker/Stop.php
+++ b/src/Command/Docker/Stop.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -12,9 +12,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class ComposerRun.
+ * Class Stop.
  */
-class ComposerRun extends DockerCommand
+class Stop extends DockerCommand
 {
     /**
      * {@inheritdoc}
@@ -22,13 +22,9 @@ class ComposerRun extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:comprun')->setDescription('Run Composer command in the engine.');
-        $this->setAliases(['comprun']);
-        $this->addArgument(
-            'compcommand',
-            InputArgument::IS_ARRAY,
-            'Composer Command to run in. Use "" to pass options.'
-        );
+        $this->setName('docker:stop')->setDescription('Stop all the services (or just one).');
+        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to stop', '');
+        $this->setAliases(['stop']);
     }
 
     /**
@@ -36,8 +32,6 @@ class ComposerRun extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $allArguments = $input->getArgument('compcommand');
-        $options      = '';
-        $this->taskExecutor->runComposerCommand(implode(' ', $allArguments)." {$options}");
+        $this->dockerClient->stop($input->getArgument('service'));
     }
 }

--- a/src/Command/Docker/SymfonyRun.php
+++ b/src/Command/Docker/SymfonyRun.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Command/Docker/Up.php
+++ b/src/Command/Docker/Up.php
@@ -4,7 +4,7 @@
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace eZ\Launchpad\Command;
+namespace eZ\Launchpad\Command\Docker;
 
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -12,9 +12,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class Build.
+ * Class Up.
  */
-class Build extends DockerCommand
+class Up extends DockerCommand
 {
     /**
      * {@inheritdoc}
@@ -22,9 +22,9 @@ class Build extends DockerCommand
     protected function configure()
     {
         parent::configure();
-        $this->setName('docker:build')->setDescription('Build all the services (or just one).');
-        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to build', '');
-        $this->setAliases(['build']);
+        $this->setName('docker:up')->setDescription('Up all the services (or just one).');
+        $this->addArgument('service', InputArgument::OPTIONAL, 'Service to up', '');
+        $this->setAliases(['up']);
     }
 
     /**
@@ -32,6 +32,6 @@ class Build extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->dockerClient->build([], $input->getArgument('service'));
+        $this->dockerClient->up(['-d'], $input->getArgument('service'));
     }
 }

--- a/src/Command/Platformsh/Deploy.php
+++ b/src/Command/Platformsh/Deploy.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license   For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Launchpad\Command\Platformsh;
+
+use eZ\Launchpad\Core\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Class Deploy.
+ */
+class Deploy extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('platformsh:deploy')->setDescription('Deploy with Platformsh integration.');
+        $this->setAliases(['psh:deploy']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $fs = new Filesystem();
+        $this->io->title($this->getDescription());
+
+        // add a test to see if folder exists or not
+        if (!$fs->exists("{$this->projectPath}/.platform")) {
+            $this->io->error('Your project is not Platformsh ready.');
+            $this->io->comment('Run <comment>~/ez platformsh:setup</comment> to set up the integration.');
+
+            return;
+        }
+
+        $this->io->writeln(
+            "There is no such thing with Platform.sh.\n".
+            'To deploy you just have to <comment>git push</comment> in the good'.
+            " <comment>remote</comment> (usually: platform)\n".
+            "Automatically Platform.sh will trigger the deployment.\n".
+            "\nIf you just want to manage one unique git repository have a look: \n".
+            "\t<fg=cyan>Github Integration</>:\t https://docs.platform.sh/administration/integrations/github.html\n".
+            "\t<fg=cyan>Bitbucket Integration</>:\t https://docs.platform.sh/administration/integrations/bitbucket.html"
+        );
+    }
+}

--- a/src/Command/Platformsh/Setup.php
+++ b/src/Command/Platformsh/Setup.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license   For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Launchpad\Command\Platformsh;
+
+use eZ\Launchpad\Core\DockerCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Class Setup.
+ */
+class Setup extends DockerCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('platformsh:setup')->setDescription('Set up the Platformsh integration.');
+        $this->setAliases(['psh:setup']);
+    }
+
+    /**
+     *  Post Actions.
+     */
+    protected function postAction()
+    {
+        $this->io->writeln(
+            'You can also look at <comment>~/ez platformsh:deploy</comment>.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $fs = new Filesystem();
+        $this->io->title($this->getDescription());
+
+        // add a test to see if folder exists or not
+        if ($fs->exists("{$this->projectPath}/.platform")) {
+            if (!$this->io->confirm(
+                'You already have a <comment>.platform</comment> folder, do you want to continue?'
+            )
+            ) {
+                $this->postAction();
+
+                return;
+            }
+        }
+
+        // Install Tiny help for Platformsh (will be included soon in ezplatform)
+        $this->taskExecutor->runComposerCommand(
+            'require platformsh/config-reader --no-interaction --no-scripts --optimize-autoloader --no-update'
+        );
+        // Dump the project
+        $this->taskExecutor->dumpData();
+
+        // put the files in places
+        $fs->mirror("{$this->getPayloadDir()}/platformsh/.platform", "{$this->projectPath}/.platform");
+        $fs->copy("{$this->getPayloadDir()}/platformsh/.platform.app.yaml", "{$this->projectPath}/.platform.app.yaml");
+        $provisioningName   = $this->projectConfiguration->get('provisionning.folder_name');
+        $provisioningFolder = "{$this->projectPath}/{$provisioningName}";
+        $fs->copy(
+            "{$this->getPayloadDir()}/platformsh/getmysqlcredentials.php",
+            "{$provisioningFolder}/platformsh/getmysqlcredentials.php",
+            true
+        );
+        $fs->copy(
+            "{$this->getPayloadDir()}/platformsh/platformsh.php",
+            "{$this->projectPath}/ezplatform/app/config/env/platformsh.php",
+            true
+        );
+
+        // manage the memcache service or not
+        $services = Yaml::parse(
+            file_get_contents("{$this->getPayloadDir()}/platformsh/.platform/services.yaml")
+        );
+        if (!$this->projectConfiguration->getDockerCompose()->hasService('memcache')) {
+            unset($services['cache']);
+        }
+        $yaml = Yaml::dump($services);
+        $fs->dumpFile("{$this->projectPath}/.platform/services.yaml", $yaml);
+        $this->io->writeln(
+            "Your project is now set up with Platform.sh.\n".
+            "You can run <comment>git status</comment> to see the changes\n".
+            "Then you just have to \n".
+            "\t<comment>git add .</comment>\n".
+            "\t<comment>git commit -m \"Integration Platform.sh\"</comment>\n".
+            "\t<comment>git push platform {branchname}</comment>\n"
+        );
+        $this->postAction();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | feature-platformsh
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no

The idea is to set up platformsh with the local stack. To do that few things has to be done:

- [x] provide the _.platform_ and _.platform.app.yml_
- [x] adapt the _.platform_ and _.platform.app.yml_ because `ezplatform` is not the root now with eZ Launchpad
- [x] Adapt and map the services depending on services enabled with the local stack
- [x] Put the good _.platform_ and _.platform.app.yml_ into their correct places
- [x] update the documentation to explain the approach

Note: To me, there is no real reason to have a command that would "deploy" for Platformsh. The whole point is to deploy through git.
But we need something like `~/ez platformsh:setup` that would do the mapping and file copies

- [x] Also it might mean a revamp of the Command folder to group commands by "prefix" docker and platformsh for now

- [ ] TBD: we could wrap some `platformsh` command if needed, need to think more on that.
