### PR TITLE
Working directory fix

### DIFF
--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -18,7 +18,10 @@ services:
             - PROJECTMAPPINGFOLDER
 
     engine:
-        build: ./engine/
+        build:
+            context: ./engine/
+            args:
+                - PROJECTMAPPINGFOLDER
         volumes:
             - "${PROJECTCOMPOSEPATH}/${PROVISIONINGFOLDERNAME}/dev/engine/php.ini:/usr/local/etc/php/php.ini:ro"
             - "${PROJECTCOMPOSEPATH}:${PROJECTMAPPINGFOLDER}:rw"

--- a/payload/dev/engine/Dockerfile
+++ b/payload/dev/engine/Dockerfile
@@ -5,3 +5,5 @@ COPY entrypoint.bash /entrypoint.bash
 RUN chmod +x /entrypoint.bash
 ENTRYPOINT ["/entrypoint.bash"]
 CMD ["php-fpm"]
+
+WORKDIR /var/www/html/project/ezplatform/

--- a/payload/dev/engine/Dockerfile
+++ b/payload/dev/engine/Dockerfile
@@ -6,4 +6,6 @@ RUN chmod +x /entrypoint.bash
 ENTRYPOINT ["/entrypoint.bash"]
 CMD ["php-fpm"]
 
-WORKDIR /var/www/html/project/ezplatform/
+ARG PROJECTMAPPINGFOLDER
+RUN mkdir -p ${PROJECTMAPPINGFOLDER}/ezplatform
+WORKDIR ${PROJECTMAPPINGFOLDER}/ezplatform


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating docs/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | 

Set project dir as "default". For example the `assets:install` sf command doesn't run without it.