### PR TITLE
Feature ubuntu docker compose env error fix

### DIFF
--- a/src/Core/Client/Docker.php
+++ b/src/Core/Client/Docker.php
@@ -328,6 +328,7 @@ class Docker
                 'DOCKER_HOST'             => getenv('DOCKER_HOST'),
                 'DOCKER_CERT_PATH'        => getenv('DOCKER_CERT_PATH'),
                 'DOCKER_TLS_VERIFY'       => getenv('DOCKER_TLS_VERIFY'),
+                'PATH'                    => getenv('PATH')
             ];
     }
 

--- a/src/Core/Client/DockerSync.php
+++ b/src/Core/Client/DockerSync.php
@@ -136,6 +136,7 @@ class DockerSync
                 'PROVISIONINGFOLDERNAME' => $this->getProvisioningFolderName(),
                 'COMPOSEFILE'            => $this->getComposeFileName(),
                 'HOME'                   => getenv('HOME'),
+                'PATH'                    => getenv('PATH')
             ];
     }
 

--- a/tests/Tests/Unit/TestCase.php
+++ b/tests/Tests/Unit/TestCase.php
@@ -169,6 +169,7 @@ docker:
             'DOCKER_HOST'             => getenv('DOCKER_HOST'),
             'DOCKER_CERT_PATH'        => getenv('DOCKER_CERT_PATH'),
             'DOCKER_TLS_VERIFY'       => getenv('DOCKER_TLS_VERIFY'),
+            'PATH'                    => getenv('PATH'),
         ];
     }
 }


### PR DESCRIPTION
On Ubuntu, docker-compose is crashing as it does not find the PATH env var.

No issue on Mac, Debian, on Travis etc..

It does not hurt to fix that issue that way....