### PR TITLE
EZP-28820: [Solr] Does not index on publish (and crash on search)

### DIFF
--- a/payload/dev/solr/entrypoint.bash
+++ b/payload/dev/solr/entrypoint.bash
@@ -5,6 +5,7 @@ if [ ! -f /ezsolr/server/ez/solr.xml ]; then
     cp /opt/solr/server/solr/solr.xml /ezsolr/server/ez
     cp /opt/solr/server/solr/configsets/basic_configs/conf/{currency.xml,solrconfig.xml,stopwords.txt,synonyms.txt,elevate.xml} /ezsolr/server/ez/template
     sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema">/,/<\/updateRequestProcessorChain>/d' /ezsolr/server/ez/template/solrconfig.xml
+    sed -i -e 's/<maxTime>${solr.autoSoftCommit.maxTime:-1}<\/maxTime>/<maxTime>${solr.autoSoftCommit.maxTime:20}<\/maxTime>/g' /ezsolr/server/ez/template/solrconfig.xml
 fi
 
 /opt/solr/bin/solr -s /ezsolr/server/ez -f


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | https://jira.ez.no/browse/EZP-28820

This PR solves an issue related to the Solr which doesn't index content on publish and crashes on search. There was default `autoSoftCommit` value (`-1`), this PR changes it to `20` as recommended in the documentation.
