### PR TITLE
set default answer to true for http basic if composer auth is needed

### DIFF
--- a/src/Core/ProjectWizard.php
+++ b/src/Core/ProjectWizard.php
@@ -107,7 +107,7 @@ END;
         $credentials    = [];
         $endString      = '<fg=yellow;options=bold>Composer HTTP-BASIC</> for this project?';
         $questionString = 'Do you want to set '.$endString;
-        while ($this->io->confirm($questionString, false)) {
+        while ($this->io->confirm($questionString, true)) {
             list($host, $login, $password) = $this->getOneComposerHttpBasic();
 
             $credentials[]  = [$host, $login, $password];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating docs/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | 

When users says the want the options standard-with-http-auth, default anwser for the question should be `yes` instead of no. 

i've seen the condition 
```php
if (!$this->requireComposerAuth()) {
      return [];
}```

which makes the function return is `0` was selected at first place. now, when `1` is selected (standard with-composer-auth) the default answer will be `yes`, while if mode expert is selected, it will be `false` as it happens now. 

@Plopix , now another question is... do we need to ask this question thinking that the users have already said they want this when they select `1` at first place?