### PR TITLE
Add env variables for redis session storage

### DIFF
--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -40,6 +40,8 @@ services:
             - "CACHE_REDIS_PORT=6379"
             - "CACHE_POOL=cache.redis"
             - "CACHE_DSN=redis:6379"
+            - "SESSION_STORAGE_HOST=redis"
+            - "SESSION_STORAGE_DSN=redis:6379"
             - "SEARCH_ENGINE=solr"
             - "SOLR_DSN=http://solr:8983/solr"
             - "SYMFONY_TMP_DIR=/tmp/ezplatformcache/"

--- a/src/Core/DockerCompose.php
+++ b/src/Core/DockerCompose.php
@@ -118,6 +118,8 @@ class DockerCompose
                             'CACHE_REDIS_PORT',
                             'CACHE_POOL',
                             'CACHE_DSN',
+                            'SESSION_STORAGE_HOST',
+                            'SESSION_STORAGE_DSN',
                             'SEARCH_ENGINE',
                             'SOLR_DSN',
                             'HTTPCACHE_PURGE_SERVER',
@@ -154,7 +156,7 @@ class DockerCompose
                         }
                         if (!$this->hasService('redis')) {
                             if (preg_match(
-                                '/(CUSTOM_CACHE_POOL|CACHE_HOST|CACHE_POOL|CACHE_DSN|CACHE_REDIS_PORT)/',
+                                '/(CUSTOM_CACHE_POOL|CACHE_HOST|CACHE_POOL|CACHE_DSN|CACHE_REDIS_PORT|SESSION_STORAGE_HOST|SESSION_STORAGE_DSN|)/',
                                 $value
                             )) {
                                 return false;


### PR DESCRIPTION
This add's two new env variables for ezplatform's generic.php file to use a redis service for session handling.