### PR TITLE
Move solr core 'data' folder

### DIFF
--- a/payload/dev/solr/.gitignore
+++ b/payload/dev/solr/.gitignore
@@ -1,1 +1,0 @@
-server/ez/collection1/data

--- a/payload/dev/solr/entrypoint.bash
+++ b/payload/dev/solr/entrypoint.bash
@@ -6,6 +6,7 @@ if [ ! -f /ezsolr/server/ez/solr.xml ]; then
     cp /opt/solr/server/solr/configsets/basic_configs/conf/{currency.xml,solrconfig.xml,stopwords.txt,synonyms.txt,elevate.xml} /ezsolr/server/ez/template
     sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema">/,/<\/updateRequestProcessorChain>/d' /ezsolr/server/ez/template/solrconfig.xml
     sed -i -e 's/<maxTime>${solr.autoSoftCommit.maxTime:-1}<\/maxTime>/<maxTime>${solr.autoSoftCommit.maxTime:20}<\/maxTime>/g' /ezsolr/server/ez/template/solrconfig.xml
+    sed -i -e 's/<dataDir>${solr.data.dir:}<\/dataDir>/<dataDir>\/opt\/solr\/data\/${solr.core.name}<\/dataDir>/g' /ezsolr/server/ez/template/solrconfig.xml
 fi
 
 /opt/solr/bin/solr -s /ezsolr/server/ez -f

--- a/src/Command/Docker/Create.php
+++ b/src/Command/Docker/Create.php
@@ -57,8 +57,6 @@ class Create extends DockerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->taskExecutor->handlePermissions();
-
         $this->dockerClient->build(['--no-cache']);
         $this->dockerClient->up(['-d']);
 

--- a/src/Core/TaskExecutor.php
+++ b/src/Core/TaskExecutor.php
@@ -56,23 +56,6 @@ class TaskExecutor
     }
 
     /**
-     * Manage permissions.
-     */
-    public function handlePermissions()
-    {
-        // Fix a permissions issue with data/
-        // we ensure that Solr will be able to write on data/ which is owned by the user hosts
-        // @todo: find a way to do better
-        $provisioningFolder  = $this->projectConfiguration->get('provisioning.folder_name');
-        $ezSolrCollectionDir = "{$provisioningFolder}/dev/solr/server/ez/collection1";
-        $fs                  = new Filesystem();
-        if ($fs->exists($ezSolrCollectionDir)) {
-            $fs->mkdir("{$ezSolrCollectionDir}/data");
-            $fs->chmod("{$ezSolrCollectionDir}/data", 0777);
-        }
-    }
-
-    /**
      * @return Process[]
      */
     public function composerInstall()


### PR DESCRIPTION
Move data folder from shared volume. This fixes the perms issues with sharing the data folder without needing to 777 it. 

Helps with setting up multi-core.