### PR TITLE
Configuration cron ezplatform 

### DIFF
--- a/payload/platformsh/.platform.app.yaml
+++ b/payload/platformsh/.platform.app.yaml
@@ -74,6 +74,9 @@ hooks:
 #    symfony:
 #        spec: "*/20 * * * *"
 #        cmd: "php cron.php example:test"
+#    ezplatform:
+#        spec: "* * * * *"
+#        cmd: "cd ezplatform; php php bin/console ezplatform:cron:run --env=prod"
 
 runtime:
     extensions:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | fix-arbo-cron
| Bug fix?      | yes
| New feature?  | no

In the case of an ez platform project.
You have to change the path to start the cron command.
We must add cd ezplatform;
for exemple : cmd: "cd ezplatform; php bin/console ezplatform:cron:run --env=prod"