### PR TITLE
Support non-tty systems (CI)

### DIFF
--- a/src/Core/Client/Docker.php
+++ b/src/Core/Client/Docker.php
@@ -231,6 +231,11 @@ class Docker
         $args[] = $service;
         $args[] = $command;
 
+        // Disable TTY if is not supported by the host (CI)
+        if (!$this->runner->hasTty()) {
+            array_unshift($args, '-T');
+        }
+
         return $this->perform('exec', '', $args);
     }
 

--- a/tests/Tests/Unit/TestCase.php
+++ b/tests/Tests/Unit/TestCase.php
@@ -144,6 +144,10 @@ docker:
                 )
             );
 
+        $processRunnerMock
+            ->method('hasTty')
+            ->willReturn(true);
+
         return new Docker($options, $processRunnerMock);
     }
 

--- a/tests/Tests/Unit/TestCase.php
+++ b/tests/Tests/Unit/TestCase.php
@@ -120,9 +120,10 @@ docker:
     }
 
     /**
+     * @param bool $hasTty
      * @return Docker
      */
-    public function getDockerClient()
+    public function getDockerClient($hasTty = true)
     {
         $options = [
             'compose-file'             => $this->getDockerComposeFilePath(),
@@ -146,7 +147,7 @@ docker:
 
         $processRunnerMock
             ->method('hasTty')
-            ->willReturn(true);
+            ->willReturn($hasTty);
 
         return new Docker($options, $processRunnerMock);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating docs/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | -

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

I want to build an application in CI (Gitlab) with eZ Launchpad.

When I executed `~/ez docker:create`, the script has failed:

```
$ ~/ez docker:create --no-interaction

In Process.php line 1042:
                                                   
  TTY mode requires /dev/tty to be read/writable.  
```

CI does not support TTY but it's required in the code except Windows platform. I've enhanced the condition to check not only the platform, but actual support of TTY.

Also this information is now propagated to Docker client which runs `docker-compose exec -T` on platform which does not support TTY. Without `-T` option, `docker-compose exec` allocated TTY by default and it would not work.
