### PR TITLE
Add workdir for engine

### DIFF
--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -24,6 +24,7 @@ services:
             - "${PROJECTCOMPOSEPATH}:${PROJECTMAPPINGFOLDER}:rw"
             - "${HOST_COMPOSER_CACHE_DIR}:${COMPOSER_CACHE_DIR}:rw"
             - "${PROJECTCOMPOSEPATH}/${PROVISIONINGFOLDERNAME}/dev/solr:/ezsolr:rw"
+        working_dir: /var/www/html/project/ezplatform
         shm_size: 754M
         environment:
             - COMPOSER_CACHE_DIR

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -93,6 +93,14 @@ class Initialize extends Command
 
         $compose->filterServices($selectedServices);
 
+        $fs->mkdir("ezplatform");
+        $fs->chmod(
+            [
+                "ezplatform",
+            ],
+            0755
+        );
+
         // start the scafolding of the Payload
         $provisioningFolder = "{$this->projectPath}/{$provisioningName}";
         $fs->mkdir("{$provisioningFolder}/dev");


### PR DESCRIPTION
Once you enter the container, navigation to the ezplatform folder should be there right away