### PR TITLE
Add support for using composer install commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## CHANGELOG
 
+### ?.?.?
+
+- Add support for calling composer ezplatform-install (script) on "initialdata" argument
+
+
 ### 1.4.0
 
 - Add SOLR_CORES env variable on solr container to define the core(s) name. (default = "collection1")

--- a/payload/recipes/ez_install.bash
+++ b/payload/recipes/ez_install.bash
@@ -45,7 +45,15 @@ if [ -f app/console ]; then
     CONSOLE="app/console"
 fi
 
-$PHP $CONSOLE ezplatform:install $INIT_DATA
+
+# Prefer install via composer alias (added in v2.2, required for eZ Commerce)
+if $COMPOSER run-script -l | grep -q " $INIT_DATA "; then
+   $COMPOSER run-script $INIT_DATA
+else
+    $PHP $CONSOLE ezplatform:install $INIT_DATA
+fi
+
+
 
 echo "Installation OK"
 

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -57,7 +57,7 @@ class Initialize extends Command
         $this->setAliases(['docker:init', 'initialize', 'init']);
         $this->addArgument('repository', InputArgument::OPTIONAL, 'eZ Platform Repository', 'ezsystems/ezplatform');
         $this->addArgument('version', InputArgument::OPTIONAL, 'eZ Platform Version', '2.*');
-        $this->addArgument('initialdata', InputArgument::OPTIONAL, 'eZ Platform Initial', 'clean');
+        $this->addArgument('initialdata', InputArgument::OPTIONAL, 'eZ Platform installer. Composer install script like "ezplatform-install" checked for first, if not using as argument for install command directly)', 'clean');
     }
 
     /**
@@ -190,6 +190,8 @@ class Initialize extends Command
 
         if ('clean' === $initialdata && false !== strpos($repository, 'ezplatform-ee')) {
             $initialdata = 'ezplatform-ee-clean';
+        } elseif ('clean' === $initialdata && false !== strpos($repository, 'ezcommerce')) {
+            $initialdata = 'ezcommerce-install';
         }
 
         $executor->eZInstall($input->getArgument('version'), $repository, $initialdata);

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -57,7 +57,12 @@ class Initialize extends Command
         $this->setAliases(['docker:init', 'initialize', 'init']);
         $this->addArgument('repository', InputArgument::OPTIONAL, 'eZ Platform Repository', 'ezsystems/ezplatform');
         $this->addArgument('version', InputArgument::OPTIONAL, 'eZ Platform Version', '2.*');
-        $this->addArgument('initialdata', InputArgument::OPTIONAL, 'eZ Platform installer. Composer install script like "ezplatform-install" checked for first, if not using as argument for install command directly)', 'clean');
+        $this->addArgument(
+            'initialdata',
+            InputArgument::OPTIONAL,
+            'Installer: If avaiable uses "composer run-script <initialdata>", if not uses ezplatform:install command',
+            'clean'
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | ?
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | N/A

As of v2.2 we started adding alias command in composer for install, it should be safe from one flavour to the next so I'm tempted to put it as a default but that would bump requirements to 2.2.

This is furthermore a requriments for adding Commerce support as it aliases several function calls:
https://github.com/ezsystems/ezcommerce/blob/master/composer.json#L117-L123

_Note1: Unsure how compatible the bash code added here is, might be better way to handle this also._
_Note2: Full Commerce support probably needs additional fixes on solr and potentially other things._
