### PR TITLE
Fix redis commander environment variables

### DIFF
--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     redisadmin:
         image: rediscommander/redis-commander:latest
         environment:
-            - "REDIS_HOSTS=local:redis:6379"
+            - REDIS_HOST=redis
         ports:
             - "${PROJECTPORTPREFIX}083:8081"
 


### PR DESCRIPTION
For the latest version of redis commander, the host connection has changed. 
If you use redis_hosts it tries to connect to a local redis instances which one doesn't exist on the redis commander container so the redis admin container logs report unable to connect warnings.