### PR TITLE
Add support for installing demo installs

### DIFF
--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -195,7 +195,7 @@ class Initialize extends Command
 
         $version = $input->getArgument('version');
         // Change default when on eZ Platform v1 to "clean" / "ezplatform-ee-clean"
-        if ('ezplatform-install' === $initialdata && 1 == (int)str_replace(['^', '~'], '', $var)) {
+        if ('ezplatform-install' === $initialdata && 1 == (int)str_replace(['^', '~'], '', $version)) {
             $initialdata = (false !== strpos($repository, 'ezplatform-ee') ? 'ezplatform-ee-clean' : 'clean');
         }
 

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -61,7 +61,7 @@ class Initialize extends Command
             'initialdata',
             InputArgument::OPTIONAL,
             'Installer: If avaiable uses "composer run-script <initialdata>", if not uses ezplatform:install command',
-            'clean'
+            'ezplatform-install'
         );
     }
 
@@ -193,13 +193,13 @@ class Initialize extends Command
         $repository  = $input->getArgument('repository');
         $initialdata = $input->getArgument('initialdata');
 
-        if ('clean' === $initialdata && false !== strpos($repository, 'ezplatform-ee')) {
-            $initialdata = 'ezplatform-ee-clean';
-        } elseif ('clean' === $initialdata && false !== strpos($repository, 'ezcommerce')) {
-            $initialdata = 'ezcommerce-install';
+        $version = $input->getArgument('version');
+        // Change default when on eZ Platform v1 to "clean"
+        if ('ezplatform-install' === $initialdata && 1 == (int)str_replace(['^', '~'], '', $var)) {
+            $initialdata = 'clean';
         }
 
-        $executor->eZInstall($input->getArgument('version'), $repository, $initialdata);
+        $executor->eZInstall($version, $repository, $initialdata);
         if ($compose->hasService('solr')) {
             $executor->eZInstallSolr();
         }

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -195,7 +195,7 @@ class Initialize extends Command
 
         $version = $input->getArgument('version');
         // Change default when on eZ Platform v1 to "clean" / "ezplatform-ee-clean"
-        if ('ezplatform-install' === $initialdata && 1 == (int)str_replace(['^', '~'], '', $version)) {
+        if ('ezplatform-install' === $initialdata && 1 === (int) str_replace(['^', '~'], '', $version)) {
             $initialdata = (false !== strpos($repository, 'ezplatform-ee') ? 'ezplatform-ee-clean' : 'clean');
         }
 

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -194,9 +194,9 @@ class Initialize extends Command
         $initialdata = $input->getArgument('initialdata');
 
         $version = $input->getArgument('version');
-        // Change default when on eZ Platform v1 to "clean"
+        // Change default when on eZ Platform v1 to "clean" / "ezplatform-ee-clean"
         if ('ezplatform-install' === $initialdata && 1 == (int)str_replace(['^', '~'], '', $var)) {
-            $initialdata = 'clean';
+            $initialdata = (false !== strpos($repository, 'ezplatform-ee') ? 'ezplatform-ee-clean' : 'clean');
         }
 
         $executor->eZInstall($version, $repository, $initialdata);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master _(next patch release)_
| Bug fix?      | yes
| BC breaks?    | no

Change installer to prefer using "ezplatform-install" composer script option available since 2.2 which works on all flavours, effectively adding support for demos. And if we detect user asking for 1.x, fallback to "clean"/"ezplatform-ee-clean" like before.

Reported by @jheba
