### PR TITLE
New ability to pass environment variables during docker-compose:exec

### DIFF
--- a/payload/dev/docker-compose-osx.yml
+++ b/payload/dev/docker-compose-osx.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.2'
 services:
     engine:
         volumes:

--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.2'
 services:
     nginx:
         image: nginx:stable-alpine

--- a/src/Command/Docker/ComposerRun.php
+++ b/src/Command/Docker/ComposerRun.php
@@ -12,6 +12,7 @@ namespace eZ\Launchpad\Command\Docker;
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ComposerRun extends DockerCommand
@@ -26,12 +27,14 @@ class ComposerRun extends DockerCommand
             InputArgument::IS_ARRAY,
             'Composer Command to run in. Use "" to pass options.'
         );
+        $this->addOption('sfenv', InputArgument::OPTIONAL, InputOption::VALUE_OPTIONAL, 'SYMFONY_ENV value', 'dev');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $allArguments = $input->getArgument('compcommand');
+        $symfonyEnv = $input->getOption('sfenv');
         $options = '';
-        $this->taskExecutor->runComposerCommand(implode(' ', $allArguments)." {$options}");
+        $this->taskExecutor->runComposerCommand(implode(' ', $allArguments)." {$options}", $symfonyEnv);
     }
 }

--- a/src/Command/Docker/ComposerRun.php
+++ b/src/Command/Docker/ComposerRun.php
@@ -12,7 +12,6 @@ namespace eZ\Launchpad\Command\Docker;
 use eZ\Launchpad\Core\DockerCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ComposerRun extends DockerCommand
@@ -27,14 +26,12 @@ class ComposerRun extends DockerCommand
             InputArgument::IS_ARRAY,
             'Composer Command to run in. Use "" to pass options.'
         );
-        $this->addOption('sfenv', InputArgument::OPTIONAL, InputOption::VALUE_OPTIONAL, 'SYMFONY_ENV value', 'dev');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $allArguments = $input->getArgument('compcommand');
-        $symfonyEnv = $input->getOption('sfenv');
         $options = '';
-        $this->taskExecutor->runComposerCommand(implode(' ', $allArguments)." {$options}", $symfonyEnv);
+        $this->taskExecutor->runComposerCommand(implode(' ', $allArguments)." {$options}");
     }
 }

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -38,6 +38,18 @@ class ApplicationFactory
         $application->setVersion('@package_version@'.(('prod' !== $env) ? '-dev' : ''));
         $application->setAutoExit($autoExit);
 
+        self::createDockerEnvParams();
+
         return $application;
+    }
+
+    private static function createDockerEnvParams() {
+        foreach ($_SERVER['argv'] as $index=>$value) {
+            $_SERVER['argv'][$index] = preg_replace(
+                '/^--env=/',
+                '--docker-env=',
+                $_SERVER['argv'][$index]
+            );
+        }
     }
 }

--- a/src/Core/DockerCommand.php
+++ b/src/Core/DockerCommand.php
@@ -36,6 +36,13 @@ abstract class DockerCommand extends Command
     protected function configure(): void
     {
         $this->addOption('env', 'env', InputOption::VALUE_REQUIRED, 'Docker Env', 'dev');
+        $this->addOption(
+            '--docker-env',
+            null,
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'Environment variables used by docker-composer:exec',
+            []
+        );
     }
 
     public function getDockerClient(): Docker
@@ -73,7 +80,8 @@ abstract class DockerCommand extends Command
         $this->taskExecutor = new TaskExecutor(
             $this->dockerClient,
             $this->projectConfiguration,
-            $this->requiredRecipes
+            $this->requiredRecipes,
+            $input->getOption('docker-env')
         );
     }
 }

--- a/src/Core/TaskExecutor.php
+++ b/src/Core/TaskExecutor.php
@@ -160,23 +160,26 @@ class TaskExecutor
         return $this->execute("ezplatform/{$consolePath} {$arguments}");
     }
 
-    public function runComposerCommand(string $arguments): Process
+    public function runComposerCommand(string $arguments, string $symfonyEnv = 'dev'): Process
     {
         return $this->globalExecute(
-            '/usr/local/bin/composer --working-dir='.$this->dockerClient->getProjectPathContainer().'/ezplatform '.
-            $arguments
+            "/usr/local/bin/composer --working-dir={$this->dockerClient->getProjectPathContainer()}/ezplatform ".
+            $arguments, $symfonyEnv
         );
     }
 
-    protected function execute(string $command, string $user = 'www-data', string $service = 'engine')
+    protected function execute(string $command, string $symfonyEnv = 'dev', string $user = 'www-data', string $service = 'engine')
     {
         $command = $this->dockerClient->getProjectPathContainer().'/'.$command;
 
-        return $this->globalExecute($command, $user, $service);
+        return $this->globalExecute($command, $symfonyEnv, $user, $service);
     }
 
-    protected function globalExecute(string $command, string $user = 'www-data', string $service = 'engine')
+    protected function globalExecute(string $command, string $symfonyEnv = 'dev', string $user = 'www-data', string $service = 'engine')
     {
-        return $this->dockerClient->exec($command, ['--user', $user], $service);
+        return $this->dockerClient->exec($command, [
+            '--user', $user,
+            '--env', "SYMFONY_ENV={$symfonyEnv}"
+        ], $service);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes

New ability to pass environment variables during docker-compose:exec

Example of use: 
`~/ez comprun symfony-scripts --env=SYMFONY_ENV=prod --env=MY_VAR=true`