### PR TITLE
Passing env vars from CLI to docker commands

### DIFF
--- a/payload/dev/docker-compose-osx.yml
+++ b/payload/dev/docker-compose-osx.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.2'
 services:
     engine:
         volumes:

--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.2'
 services:
     nginx:
         image: nginx:stable-alpine

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -126,8 +126,8 @@ class Initialize extends Command
 
         // eZ Platform <3 only support solr 6. Replace unsupported solr 7.7 by 6.6.2
         if (
-                ( (1 === (int) str_replace(['^', '~'], '', $normalizedVersion)) ||
-                  (2 === (int) str_replace(['^', '~'], '', $normalizedVersion)) ) &&
+                ((1 === (int) str_replace(['^', '~'], '', $normalizedVersion)) ||
+                  (2 === (int) str_replace(['^', '~'], '', $normalizedVersion))) &&
                 $compose->hasService('solr')
         ) {
             $composeFilePath = "{$provisioningFolder}/dev/{$composeFileName}";

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -38,19 +38,6 @@ class ApplicationFactory
         $application->setVersion('@package_version@'.(('prod' !== $env) ? '-dev' : ''));
         $application->setAutoExit($autoExit);
 
-        self::createDockerEnvParams();
-
         return $application;
-    }
-
-    private static function createDockerEnvParams()
-    {
-        foreach ($_SERVER['argv'] as $index => $value) {
-            $_SERVER['argv'][$index] = preg_replace(
-                '/^--env=/',
-                '--docker-env=',
-                $_SERVER['argv'][$index]
-            );
-        }
     }
 }

--- a/src/Console/ApplicationFactory.php
+++ b/src/Console/ApplicationFactory.php
@@ -38,6 +38,19 @@ class ApplicationFactory
         $application->setVersion('@package_version@'.(('prod' !== $env) ? '-dev' : ''));
         $application->setAutoExit($autoExit);
 
+        self::createDockerEnvParams();
+
         return $application;
+    }
+
+    private static function createDockerEnvParams()
+    {
+        foreach ($_SERVER['argv'] as $index => $value) {
+            $_SERVER['argv'][$index] = preg_replace(
+                '/^--env=/',
+                '--docker-env=',
+                $_SERVER['argv'][$index]
+            );
+        }
     }
 }

--- a/src/Core/DockerCommand.php
+++ b/src/Core/DockerCommand.php
@@ -35,12 +35,12 @@ abstract class DockerCommand extends Command
 
     protected function configure(): void
     {
-        $this->addOption('env', 'env', InputOption::VALUE_REQUIRED, 'Docker Env', 'dev');
+        $this->addOption('env', 'e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev');
         $this->addOption(
             '--docker-env',
-            null,
+            'd',
             InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-            'Environment variables used by docker-composer:exec',
+            'Docker environment variables',
             []
         );
     }

--- a/src/Core/DockerCommand.php
+++ b/src/Core/DockerCommand.php
@@ -37,7 +37,7 @@ abstract class DockerCommand extends Command
     {
         $this->addOption('env', 'e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev');
         $this->addOption(
-            '--docker-env',
+            'docker-env',
             'd',
             InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
             'Docker environment variables',

--- a/src/Core/DockerCommand.php
+++ b/src/Core/DockerCommand.php
@@ -36,6 +36,13 @@ abstract class DockerCommand extends Command
     protected function configure(): void
     {
         $this->addOption('env', 'env', InputOption::VALUE_REQUIRED, 'Docker Env', 'dev');
+        $this->addOption(
+            '--docker-env',
+            null,
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'Environment variables used by docker-composer:exec',
+            []
+        );
     }
 
     public function getDockerClient(): Docker
@@ -73,7 +80,8 @@ abstract class DockerCommand extends Command
         $this->taskExecutor = new TaskExecutor(
             $this->dockerClient,
             $this->projectConfiguration,
-            $this->requiredRecipes
+            $this->requiredRecipes,
+            $input->getOption('docker-env')
         );
     }
 }

--- a/src/Core/TaskExecutor.php
+++ b/src/Core/TaskExecutor.php
@@ -32,11 +32,21 @@ class TaskExecutor
      */
     protected $recipes;
 
-    public function __construct(DockerClient $dockerClient, ProjectConfiguration $configuration, Collection $recipes)
-    {
+    /**
+     * @var array Docker environment variables
+     */
+    protected $dockerEnvVars;
+
+    public function __construct(
+        DockerClient $dockerClient,
+        ProjectConfiguration $configuration,
+        Collection $recipes,
+        array $dockerEnvVars = []
+    ) {
         $this->dockerClient = $dockerClient;
         $this->projectConfiguration = $configuration;
         $this->recipes = $recipes;
+        $this->dockerEnvVars = $dockerEnvVars;
     }
 
     protected function checkRecipeAvailability(string $recipe): void
@@ -177,6 +187,12 @@ class TaskExecutor
 
     protected function globalExecute(string $command, string $user = 'www-data', string $service = 'engine')
     {
-        return $this->dockerClient->exec($command, ['--user', $user], $service);
+        $args = ['--user', $user];
+
+        foreach ($this->dockerEnvVars as $envVar) {
+            $args = array_merge($args, ['--env', $envVar]);
+        }
+
+        return $this->dockerClient->exec($command, $args, $service);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes

New ability to pass environment variables during docker-compose:exec

Example of use: 
`~/ez comprun symfony-scripts --docker-env=SYMFONY_ENV=prod --docker-env=MY_VAR=true`
`~/ez comprun symfony-scripts -dSYMFONY_ENV=prod -dMY_VAR=true`