### PR TITLE
Default the Session in Redis

### DIFF
--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -47,6 +47,8 @@ services:
             - "SOLR_DSN=http://solr:8983/solr"
             - "SYMFONY_TMP_DIR=/tmp/ezplatformcache/"
             - "HTTPCACHE_VARNISH_INVALIDATE_TOKEN=eZlaunchpad20Secret09Varnish"
+            - "SESSION_HANDLER_ID=ezplatform.core.session.handler.native_redis"
+            - "SESSION_SAVE_PATH=tcp://redis:6379"
     db:
         image: mariadb:10.3
         environment:


### PR DESCRIPTION
Redis is installed by default. 
We store the logs, cache, and other things in the container to avoid writings on the Host.
Sessions should be always treated that way.

This is a HUGE performance improve for Mac OS users.

![ezlaunchpadPR94](https://user-images.githubusercontent.com/313532/95519195-7b582880-0979-11eb-9b80-409db3e2ddd3.jpeg)
