### PR TITLE
ADD Xdebug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ list:
 	@grep -E '^[a-zA-Z-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " ${YELLOW}%-15s${RESTORE} > %s\n", $$1, $$2}'
 	@echo "${RED}==============================${RESTORE}"
 
+.PHONY: install
+install: ## Install the vendor
+	@composer install
+
 .PHONY: codeclean
 codeclean: ## Run the codechecker
 	bash $(SCRIPS_DIR)/codechecker.bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ?.?.?
 
 - Add support for calling composer ezplatform-install (script) on "initialdata" argument
+- Add support for xdebug
 
 
 ### 1.4.0

--- a/payload/dev/docker-compose.yml
+++ b/payload/dev/docker-compose.yml
@@ -30,6 +30,9 @@ services:
             - PROJECTMAPPINGFOLDER
             - DEV_UID
             - DEV_GID
+            - XDEBUG_ENABLED
+            - "XDEBUG_CONFIG=remote_host=172.17.0.1"
+            - "PHP_IDE_CONFIG=serverName=ezplatform"
             - "EZP_TEST_REST_HOST=nginx"
             - "DATABASE_PREFIXES=DATABASE"
             - "DATABASE_USER=root"

--- a/payload/dev/engine/Dockerfile
+++ b/payload/dev/engine/Dockerfile
@@ -1,6 +1,12 @@
 FROM plopix/docker-php-ez-engine:7.4
 MAINTAINER Plopix
 
+ENV XDEBUG_ENABLED=0
+
+RUN mkdir /usr/local/etc/php/enable-xdebug
+
+COPY xdebug.ini /usr/local/etc/php/enable-xdebug/99-xdebug.ini
+
 COPY entrypoint.bash /entrypoint.bash
 RUN chmod +x /entrypoint.bash
 ENTRYPOINT ["/entrypoint.bash"]

--- a/payload/dev/engine/entrypoint.bash
+++ b/payload/dev/engine/entrypoint.bash
@@ -32,4 +32,8 @@ then
 fi
 /usr/local/bin/composer self-update --1
 
+if [ "1" = "${XDEBUG_ENABLED}" ]; then
+    export PHP_INI_SCAN_DIR=:/usr/local/etc/php/enable-xdebug
+fi
+
 exec "$@"

--- a/payload/dev/engine/php.ini
+++ b/payload/dev/engine/php.ini
@@ -19,16 +19,6 @@ sendmail_path = /usr/bin/env catchmail --smtp-ip mailcatcher --smtp-port 1025 -f
 extension=blackfire.so
 blackfire.agent_socket=tcp://blackfire:8707
 
-# X-Debug is disable by default, uncomment and run 'ez stop engine; ez build engine; ez up engine' to enable it
-#zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so
-#xdebug.remote_enable=1
-## Using Linux? define the correct host and if you find a automated way to do it: tell us on the channel #ez-launchpad
-#xdebug.remote_host=host.docker.internal
-#xdebug.remote_port=9000
-#xdebug.max_nesting_level=1000
-#xdebug.remote_autostart=1
-#xdebug.remote_connect_back=0
-
 [Date]
 date.timezone = "America/Los_Angeles"
 

--- a/payload/dev/engine/xdebug.ini
+++ b/payload/dev/engine/xdebug.ini
@@ -1,0 +1,6 @@
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so
+xdebug.default_enable=1
+xdebug.remote_enable=1
+xdebug.max_nesting_level=1000
+xdebug.idekey=XDEBUG_IDE_KEY
+xdebug.remote_connect_back=1

--- a/src/Command/Docker/Initialize.php
+++ b/src/Command/Docker/Initialize.php
@@ -64,7 +64,7 @@ class Initialize extends Command
         $isNetgenMedia = 'netgen' === $normalizedProvider;
 
         if ($isNetgenMedia) {
-            $normalizedMajorVersion++;
+            ++$normalizedMajorVersion;
         }
 
         return $normalizedMajorVersion;

--- a/src/Core/Client/Docker.php
+++ b/src/Core/Client/Docker.php
@@ -196,6 +196,7 @@ class Docker
                 'BLACKFIRE_CLIENT_TOKEN' => getenv('BLACKFIRE_CLIENT_TOKEN'),
                 'BLACKFIRE_SERVER_ID' => getenv('BLACKFIRE_SERVER_ID'),
                 'BLACKFIRE_SERVER_TOKEN' => getenv('BLACKFIRE_SERVER_TOKEN'),
+                'XDEBUG_ENABLED' => false === getenv('XDEBUG_ENABLED') ? '0' : '1',
                 // pass the DOCKER native vars for compose
                 'DOCKER_HOST' => getenv('DOCKER_HOST'),
                 'DOCKER_CERT_PATH' => getenv('DOCKER_CERT_PATH'),

--- a/src/Core/Client/Docker.php
+++ b/src/Core/Client/Docker.php
@@ -196,12 +196,12 @@ class Docker
                 'BLACKFIRE_CLIENT_TOKEN' => getenv('BLACKFIRE_CLIENT_TOKEN'),
                 'BLACKFIRE_SERVER_ID' => getenv('BLACKFIRE_SERVER_ID'),
                 'BLACKFIRE_SERVER_TOKEN' => getenv('BLACKFIRE_SERVER_TOKEN'),
-                'XDEBUG_ENABLED' => false === getenv('XDEBUG_ENABLED') ? '0' : '1',
                 // pass the DOCKER native vars for compose
                 'DOCKER_HOST' => getenv('DOCKER_HOST'),
                 'DOCKER_CERT_PATH' => getenv('DOCKER_CERT_PATH'),
                 'DOCKER_TLS_VERIFY' => getenv('DOCKER_TLS_VERIFY'),
                 'PATH' => getenv('PATH'),
+                'XDEBUG_ENABLED' => false === getenv('XDEBUG_ENABLED') ? '0' : '1',
             ];
     }
 

--- a/tests/Tests/Unit/TestCase.php
+++ b/tests/Tests/Unit/TestCase.php
@@ -154,6 +154,7 @@ docker:
             'DOCKER_CERT_PATH' => getenv('DOCKER_CERT_PATH'),
             'DOCKER_TLS_VERIFY' => getenv('DOCKER_TLS_VERIFY'),
             'PATH' => getenv('PATH'),
+            'XDEBUG_ENABLED' => getenv('XDEBUG_ENABLED') === false ? '0' : '1'
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes -> needs to update docs and CHANGELOG
| BC breaks?    | yes

This PR brings XDEBUG option usage in ezlaunchpad using a simple environment variable `XDEBUG_ENABLED` for users.

Why ?

Xdebug enable way more capabilities than a simple var_dump : stack_trace, environment, execution loop! Unleash the power of a real debugger!
